### PR TITLE
enable pacbio hifi preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ miniasm_and_minipolish.sh long_reads.fastq.gz 8 > polished.gfa
 ## Full usage
 
 ```
-usage: minipolish [-t THREADS] [--rounds ROUNDS] [--pacbio] [-h] [--version] reads assembly
+usage: minipolish [-t THREADS] [--rounds ROUNDS] [--minimap2-preset {map-ont,map-pb,map-hifi,lr:hq}] [--skip_initial] [-h] [--version] reads assembly
 
 Minipolish
 
@@ -148,11 +148,12 @@ Positional arguments:
   assembly                       Miniasm assembly to be polished (GFA format)
 
 Settings:
-  -t THREADS, --threads THREADS  Number of threads to use for alignment and polishing (default: 12)
+  -t, --threads THREADS          Number of threads to use for alignment and polishing (default: 12)
   --rounds ROUNDS                Number of full Racon polishing rounds (default: 2)
-  --pacbio                       Use this flag for PacBio reads to make Minipolish use the map-pb
-                                 Minimap2 preset (default: assumes Nanopore reads and uses the map-ont
-                                 preset)
+  --minimap2-preset {map-ont,lr:hq,map-pb,map-hifi}
+                                 Specify the minimap2 preset to use: "map-ont" for Oxford Nanopore reads with <Q20 accuracy, "lr:hq" for Oxford Nanopore reads with Q20+ accuracy, "map-pb" for PacBio CLR, or "map-hifi" for PacBio HiFi/CCS (default: map-ont)
+  --pacbio                       DEPRECATED: Use --minimap2-preset map-pb instead. Included for backwards compatibility. Will force --minimap2-preset="map-pb". (default: False)
+  --skip_initial                 Skip the initial polishing round - appropriate if the input GFA does not have "a" lines (default: do the initial polishing round)
 
 Other:
   -h, --help                     Show this help message and exit

--- a/minipolish/racon.py
+++ b/minipolish/racon.py
@@ -22,7 +22,7 @@ from .misc import count_reads, load_fasta, count_fasta_bases, count_lines
 RACON_PATCH_SIZE = 250
 
 
-def run_racon(name, read_filename, unpolished_filename, threads, tmp_dir, pacbio):
+def run_racon(name, read_filename, unpolished_filename, threads, tmp_dir, minimap2_preset):
     if name is None:
         name = unpolished_filename
     read_count = count_reads(read_filename)
@@ -37,8 +37,7 @@ def run_racon(name, read_filename, unpolished_filename, threads, tmp_dir, pacbio
     log(f'  input:      {unpolished_filename} ({unpolished_base_count:,} bp)')
 
     # Align with minimap2
-    preset = 'map-pb' if pacbio else 'map-ont'
-    command = ['minimap2', '-t', str(threads), '-x', preset, unpolished_filename, read_filename]
+    command = ['minimap2', '-t', str(threads), '-x', minimap2_preset, unpolished_filename, read_filename]
     alignments = tmp_dir / (name + '.paf')
     minimap2_log = tmp_dir / (name + '_minimap2.log')
     with open(alignments, 'wt') as stdout, open(minimap2_log, 'w') as stderr:


### PR DESCRIPTION
## Motivation

Currently, Minipolish supports ONT and PacBio CLR (non-HiFi) reads, but not HiFi reads.

## Description

This pull request updates the Minipolish tool to replace the `--pacbio` flag with a more flexible `--minimap2-preset` option. This change allows users to specify the minimap2 preset directly, supporting "map-pb" for PacBio CLR, "map-ont" for Oxford Nanopore, and "map-hifi" for PacBio HiFi/CCS reads.

## Changes Made

- Removed the `--pacbio` flag.
- Added the `--minimap2-preset` option with three possible values: "map-pb", "map-ont", and "map-hifi".
- Updated the README and usage information to reflect these changes.
